### PR TITLE
Define default g:cursor_follows_alphabet value.

### DIFF
--- a/plugin/translit.vim
+++ b/plugin/translit.vim
@@ -70,6 +70,10 @@ if ! exists('g:translit_toggle_keymap')
     let g:translit_toggle_keymap='<C-T>'
 endif
 
+if ! exists('g:cursor_follows_alphabet')
+    let g:cursor_follows_alphabet=0
+endif
+
 
 command! TranslitOff call TranslitOff()
 command! ToggleTranslit call ToggleTranslit()


### PR DESCRIPTION
Without these lines, an error is generated on loading the file because an undefined global variable is used.
